### PR TITLE
fix: typo line 105, `2/2 = 1.0` not `2.0`

### DIFF
--- a/docs/material/01_python/01_intro/lecture.md
+++ b/docs/material/01_python/01_intro/lecture.md
@@ -93,7 +93,7 @@ Le divisioni restituiscono sempre un numero in virgola mobile. Ad esempio:
 >>> 16 / 3
 5.333333333333333
 >>> 2 / 2
-2.0
+1.0
 ```
 
 Proviamo ora ad usare altri due operatori, molto simili al classico operatore di divisione:


### PR DESCRIPTION
Piccolo typo,

```pycon
>>> 2 / 2
2.0
```

dovrebbe essere `1.0`