### PR TITLE
Varie correzioni, capitolo `02`

### DIFF
--- a/docs/material/01_python/02_syntax/lecture.md
+++ b/docs/material/01_python/02_syntax/lecture.md
@@ -209,9 +209,9 @@ for i in vals:
 
 Nonostante il codice sia già compatto, scrivere manualmente la sequenza da iterare può facilmente diventare un'operazione abbastanza complessa. Python ci viene quindi in aiuto tramite la funzione `range(i, j, s)`, che genera una sequenza avente tutti i numeri compresi tra `i` (incluso) e `j` (escluso) a passo `s`. Ad esempio, per generare i numeri compresi tra 0 e 4 scriveremo:
 
-```py
-r = range(0, 5, 1)
-print(list(r))
+```pycon
+>>> r = range(0, 5, 1)
+>>> print(list(r))
 [0, 1, 2, 3, 4]
 ```
 

--- a/docs/material/01_python/02_syntax/lecture.md
+++ b/docs/material/01_python/02_syntax/lecture.md
@@ -342,7 +342,7 @@ Il risultato sarà:
 "Valore all'interno della funzione: 1"
 ```
 
-Ciò è legato al fatto che il passaggio viene effettuato per valore, per cui la funzione `raddoppia` agirà su una *copia* della variabile passata come argomento, e non sulla variabile originaria. Se invece usassimo una funzione che modifica una lista:
+Ciò è legato al fatto che il passaggio viene effettuato per valore, per cui la funzione `raddoppia()` agirà su una *copia* della variabile passata come argomento, e non sulla variabile originaria. Se invece usassimo una funzione che modifica una lista:
 
 ```py
 def aggiungi_a_lista(lista, elemento):
@@ -360,7 +360,7 @@ Il risultato sarà:
 "Valore all'interno della funzione: [1, 2, 3]"
 ```
 
-In questo caso, essendo la lista mutabile, il passaggio viene effettuato nei fatti per *reference*: ciò significa che le operazioni comppiute all'interno della funzione `aggiungi_a_lista` agiranno sulla lista originaria.
+In questo caso, essendo la lista mutabile, il passaggio viene effettuato nei fatti per *reference*: ciò significa che le operazioni compiute all'interno della funzione `aggiungi_a_lista` agiranno sulla lista originaria.
 
 !!!note "Shallow e deep copy"
 	Di default, Python copia le variabili per mezzo di una *shallow copy*: ciò significa che un'operazione di assignment del tipo `a = b` fa in modo che `a` punti allo stesso indirizzo di memoria di `b` e, di conseguenza, ogni modifica a `b` si rifletta su `a`. Per evitare un fenomeno di questo tipo occorre usare una *deep copy* grazie alla funzione `deepcopy` della libreria `copy`.

--- a/docs/material/01_python/02_syntax/lecture.md
+++ b/docs/material/01_python/02_syntax/lecture.md
@@ -122,7 +122,7 @@ for elemento in sequenza:
 	istruzioni()
 ```
 
-Per fare un esempio, nel seguente blocco di codice vediamo come mostrare a schermo in maniera iterativa i numeri che vanno da 0 a 5:
+Per fare un esempio, nel seguente blocco di codice vediamo come mostrare a schermo in maniera iterativa i numeri che vanno da 0 a 5 (escluso):
 
 ```py
 vals = [0,1,2,3,4]

--- a/docs/material/01_python/02_syntax/lecture.md
+++ b/docs/material/01_python/02_syntax/lecture.md
@@ -306,11 +306,12 @@ raddoppia_lista(l) 			# Risultato atteso: [1, 2, 2, 4]
 **Soluzione**: usiamo la funzione `append()` in accoppiata alla funzione `randint()`.
 
 ```py
+import random
 def genera_lista_casuale(lunghezza=5):
     l = []
     for i in range(lunghezza):
-        l.append(randint(0, 10))
-    return l
+        l.append(random.randint(0, 10))
+    return print(l)
 ...
 genera_lista_casuale() 		# Possibile risultato: [3, 1, 2, 0, 6]
 genera_lista_casuale(10)	# Possibile risultato: [7, 9, 1, 10, 2, 4, 9, 1, 4, 8]

--- a/docs/material/01_python/02_syntax/lecture.md
+++ b/docs/material/01_python/02_syntax/lecture.md
@@ -242,11 +242,12 @@ E' anche possibile specificare una sequenza *decrementale* ponendo `i > j` ed `s
 l = ['Pippo', 'Pluto', 5, 'Paperino']
 for i in range(len(l)):
     print(l[i])
-# Output
-Pippo
-Pluto
-5
-Paperino
+
+# Output:
+# Pippo
+# Pluto
+# 5
+# Paperino
 ```
 
 In pratica, dato che la funzione `len(l)` ci restituisce il numero di elementi nella lista, ovvero $4$, stiamo andando a definire un range che va da 0 a 3. A questo punto, ci basterà *elemento per elemento* ai valori contenuti all'interno della lista, ed avremo ottenuto il risultato sperato.

--- a/docs/material/01_python/02_syntax/lecture.md
+++ b/docs/material/01_python/02_syntax/lecture.md
@@ -292,7 +292,10 @@ E' importante notare che:
 ```py
 def raddoppia_lista(lista):
     for i in range(len(lista)):
-        lista.append(l[i] * 2)
+        lista.append(lista[i] * 2)
+    return print(lista)
+
+
 l = [1,2]
 raddoppia_lista(l) 			# Risultato atteso: [1, 2, 2, 4]
 ```

--- a/docs/material/01_python/02_syntax/lecture.md
+++ b/docs/material/01_python/02_syntax/lecture.md
@@ -152,12 +152,12 @@ for char in string:
 A schermo vedremo in entrambi i casi il seguente risultato:
 
 ```bash
-	P
-	y
-	t
-	h
-	o
-	n
+P
+y
+t
+h
+o
+n
 ```
 
 !!!warning "No free lunches!"

--- a/docs/material/01_python/02_syntax/lecture.md
+++ b/docs/material/01_python/02_syntax/lecture.md
@@ -363,7 +363,7 @@ Il risultato sarà:
 In questo caso, essendo la lista mutabile, il passaggio viene effettuato nei fatti per *reference*: ciò significa che le operazioni compiute all'interno della funzione `aggiungi_a_lista()` agiranno sulla lista originaria.
 
 !!!note "Shallow e deep copy"
-	Di default, Python copia le variabili per mezzo di una *shallow copy*: ciò significa che un'operazione di assignment del tipo `a = b` fa in modo che `a` punti allo stesso indirizzo di memoria di `b` e, di conseguenza, ogni modifica a `b` si rifletta su `a`. Per evitare un fenomeno di questo tipo occorre usare una *deep copy* grazie alla funzione `deepcopy` della libreria `copy`.
+	Di default, Python copia le variabili per mezzo di una *shallow copy*: ciò significa che un'operazione di assignment del tipo `a = b` fa in modo che `a` punti allo stesso indirizzo di memoria di `b` e, di conseguenza, ogni modifica a `b` si rifletta su `a`. Per evitare un fenomeno di questo tipo occorre usare una *deep copy* grazie alla funzione `deepcopy()` della libreria `copy`.
 
 ### 2.6.2 - L'istruzione `pass`
 

--- a/docs/material/01_python/02_syntax/lecture.md
+++ b/docs/material/01_python/02_syntax/lecture.md
@@ -360,7 +360,7 @@ Il risultato sarà:
 "Valore all'interno della funzione: [1, 2, 3]"
 ```
 
-In questo caso, essendo la lista mutabile, il passaggio viene effettuato nei fatti per *reference*: ciò significa che le operazioni compiute all'interno della funzione `aggiungi_a_lista` agiranno sulla lista originaria.
+In questo caso, essendo la lista mutabile, il passaggio viene effettuato nei fatti per *reference*: ciò significa che le operazioni compiute all'interno della funzione `aggiungi_a_lista()` agiranno sulla lista originaria.
 
 !!!note "Shallow e deep copy"
 	Di default, Python copia le variabili per mezzo di una *shallow copy*: ciò significa che un'operazione di assignment del tipo `a = b` fa in modo che `a` punti allo stesso indirizzo di memoria di `b` e, di conseguenza, ogni modifica a `b` si rifletta su `a`. Per evitare un fenomeno di questo tipo occorre usare una *deep copy* grazie alla funzione `deepcopy` della libreria `copy`.

--- a/docs/material/01_python/02_syntax/lecture.md
+++ b/docs/material/01_python/02_syntax/lecture.md
@@ -13,8 +13,8 @@ Oltre al duck typing, esistono altri concetti che caratterizzano la sintassi di 
 	b = 3
 	c = 4
 	r_1 = a + b * c 	# Valore restituito: 14
-	r_2 = (a + b) * c	# Valore restituito: 24
-	
+	r_2 = (a + b) * c	# Valore restituito: 20
+
 	if a > 2:
 		# Questa notazione è valida, ed è equivalente ad (a > 2)
 	```
@@ -51,7 +51,7 @@ Per quello che riguarda invece la definizione di un ambito, ad esempio locale al
 Quindi:
 
 ```py
-# L'inizio della funzione, e quindi dell'ambito 
+# L'inizio della funzione, e quindi dell'ambito
 # che questa delimita, è contrassegnato dai due punti
 def funzione():	# Inizio ambito
 	# Il codice deve essere allo stesso livello di indentazione

--- a/docs/material/01_python/02_syntax/lecture.md
+++ b/docs/material/01_python/02_syntax/lecture.md
@@ -203,7 +203,7 @@ Esco!
 Riprendiamo adesso il ciclo `for` visto in precedenza.
 
 ```py
-vals = [0,1,2,3,4]
+vals = [0, 1, 2, 3, 4]
 for i in vals:
     print(i)
 ```

--- a/docs/material/01_python/02_syntax/lecture.md
+++ b/docs/material/01_python/02_syntax/lecture.md
@@ -175,9 +175,10 @@ while(condizione):
 Ad esempio:
 
 ```py
+import random
 i = True
 while (i):
-    if randint(-5, 5) > 0:
+    if random.randint(-5, 5) > 0:
         print("Continuo!")
     else:
         print("Esco!")


### PR DESCRIPTION
Propongo i cambiamenti visibili dai vari commit.

In breve:

- il risultato di `(2 + 3) * 4` è `20`
- specificato che `5` non è incluso nella lista
- rimossa indentazione
- aggiunto `import random`, modificato `randint()` in `random.randint()`
- aggiunti spazi tra elementi della lista
- corretto linguaggio blocco di codice, corretta sintassi interprete python (nel GFM un blocco di codice con linguaggio `pycon` avrà il syntax highlight corretto per l'interprete python)
- commentato l'output di di una funzione
- corretta inconsistenza `l[i]` => `lista[i]`
- aggiunto `return print(lista)`
- aggiunto `import random` per usare il metodo `randint()`, aggiunta stampa della lista
- corretto `raddoppia` in `raddoppia()`, corretto typo (comppiute)
- corretto `aggiungi_a_lista` in `aggiungi_a_lista()`
- corretto `deepcopy` in `deepcopy()`